### PR TITLE
[FIX] Expose of public endpoints 

### DIFF
--- a/gcp/k8s/main.tf
+++ b/gcp/k8s/main.tf
@@ -17,9 +17,9 @@ resource "google_container_cluster" "mockten_k8s_cluster" {
   subnetwork = var.subnet_self_link
 
   private_cluster_config {
-    enable_private_nodes = true
+    enable_private_nodes    = true
     enable_private_endpoint = false
-    master_ipv4_cidr_block = var.k8s_master_cidr
+    master_ipv4_cidr_block  = var.k8s_master_cidr
 
     master_global_access_config {
       enabled = false
@@ -28,8 +28,7 @@ resource "google_container_cluster" "mockten_k8s_cluster" {
 
   master_authorized_networks_config {
     cidr_blocks {
-      cidr_block   = "192.0.2.127/32"
-      display_name = "my-laptop-nw"
+      cidr_block   = var.master_authorized_permit_cidr
     }
   }
 

--- a/gcp/k8s/main.tf
+++ b/gcp/k8s/main.tf
@@ -18,15 +18,19 @@ resource "google_container_cluster" "mockten_k8s_cluster" {
 
   private_cluster_config {
     enable_private_nodes = true
-    enable_private_endpoint = true
+    enable_private_endpoint = false
     master_ipv4_cidr_block = var.k8s_master_cidr
 
     master_global_access_config {
-    enabled = false
+      enabled = false
     }
   }
 
   master_authorized_networks_config {
+    cidr_blocks {
+      cidr_block   = "192.0.2.127/32"
+      display_name = "my-laptop-nw"
+    }
   }
 
   maintenance_policy {

--- a/gcp/k8s/variables.tf
+++ b/gcp/k8s/variables.tf
@@ -30,3 +30,8 @@ variable "maintenance_recurrence" {
     type        = string
     default     = null
 }
+
+variable "master_authorized_permit_cidr" {
+    type        = string
+    default     = null
+}

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -75,13 +75,14 @@ module "nw" {
 }
 
 module "k8s" {
-  source                 = "./k8s"
-  k8s_location           = var.k8s_location
-  k8s_cluster_cidr       = var.k8s_cluster_cidr
-  k8s_master_cidr        = var.k8s_master_cidr
-  maintenance_start_time = var.maintenance_start_time
-  maintenance_end_time   = var.maintenance_end_time
-  maintenance_recurrence = var.maintenance_recurrence
-  vpc_self_link          = module.nw.vpc_self_link
-  subnet_self_link       = module.nw.subnet_self_link
+  source                        = "./k8s"
+  k8s_location                  = var.k8s_location
+  k8s_cluster_cidr              = var.k8s_cluster_cidr
+  k8s_master_cidr               = var.k8s_master_cidr
+  maintenance_start_time        = var.maintenance_start_time
+  maintenance_end_time          = var.maintenance_end_time
+  maintenance_recurrence        = var.maintenance_recurrence
+  master_authorized_permit_cidr = var.master_authorized_permit_cidr
+  vpc_self_link                 = module.nw.vpc_self_link
+  subnet_self_link              = module.nw.subnet_self_link
 }

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -79,3 +79,6 @@ variable "maintenance_end_time" {
 variable "maintenance_recurrence" {
     default = "FREQ=WEEKLY;BYDAY=FR,SA,SU"
 }
+variable "master_authorized_permit_cidr" {
+    default     = "192.0.2.127/32"
+}


### PR DESCRIPTION
## Overview
I fixed to expose public endpoint of master node on GKE. since GKE which is created by this Terraform only has private endpoint. In the previous state, we need to prepare bastion server that could modify K8s manifests. 
Add the laptop's IP address to the master-autorized-network so that it can work from the laptop.


https://qiita.com/atsumjp/items/8e2bbb0066d3acab4938

### Before ( No client access to the public endpoint )

<img width="784" alt="スクリーンショット 2023-06-20 20 33 51" src="https://github.com/mockten/IaC/assets/59174187/98fbdf57-694f-4b7a-8d82-a60b7971b48b">


### After ( Limited access to the public endpoint )
<img width="801" alt="スクリーンショット 2023-06-20 20 34 19" src="https://github.com/mockten/IaC/assets/59174187/2508e20c-7be4-4b10-ae44-4e5959d3b36f">
